### PR TITLE
Issues #SB-3976 fix: adding @jsonIgnore annotation on request model

### DIFF
--- a/common-util/src/main/java/org/sunbird/common/request/Request.java
+++ b/common-util/src/main/java/org/sunbird/common/request/Request.java
@@ -1,11 +1,13 @@
 package org.sunbird.common.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 /** @author Manzarul */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Request implements Serializable {
 
   private static final long serialVersionUID = -2362783406031347676L;


### PR DESCRIPTION
Adding @JsonIgnoreProperties(ignoreUnknown = true) on Request model. This is required because telemetry service is using same model and some time telemetry service received some extra key , which is not able to parse by mapper.