### PR TITLE
Issues #SB-4222 fix: telemetry generated by scheduler job is not havi…

### DIFF
--- a/common-util/src/main/java/org/sunbird/telemetry/util/TelemetryGenerator.java
+++ b/common-util/src/main/java/org/sunbird/telemetry/util/TelemetryGenerator.java
@@ -245,7 +245,7 @@ public class TelemetryGenerator {
 
     edata.put(JsonKey.TYPE, logType);
     edata.put(JsonKey.LEVEL, logLevel);
-    edata.put(JsonKey.MESSAGE, message);
+    edata.put(JsonKey.MESSAGE, message != null ? message : "");
 
     edata.put(
         JsonKey.PARAMS,


### PR DESCRIPTION
…ng message key or some time message key value is null, but for log event message is mandatory