### PR TITLE
Issues #SB-00 fix: changes for invalid processId response

### DIFF
--- a/common-util/src/main/java/org/sunbird/common/exception/ProjectCommonException.java
+++ b/common-util/src/main/java/org/sunbird/common/exception/ProjectCommonException.java
@@ -98,7 +98,7 @@ public class ProjectCommonException extends RuntimeException {
   }
 
   public static ProjectCommonException throwResourceNotFoundException() {
-    return new ProjectCommonException(
+    throw new ProjectCommonException(
         ResponseCode.resourceNotFound.getErrorCode(),
         ResponseCode.resourceNotFound.getErrorMessage(),
         ResponseCode.RESOURCE_NOT_FOUND.getResponseCode());


### PR DESCRIPTION
As of now if u pass invalid processId to know download status , it's failing with response as it's taking too long time. 