### PR TITLE
Open jdk - seems to not invoke the mocking when in static initialization

### DIFF
--- a/sunbird-notification/src/test/java/org/sunbird/notification/sms/BaseMessageTest.java
+++ b/sunbird-notification/src/test/java/org/sunbird/notification/sms/BaseMessageTest.java
@@ -51,8 +51,8 @@ public abstract class BaseMessageTest {
 		} catch (Exception e) {
 			Assert.fail("Exception while mocking static " + e.getLocalizedMessage());
 		}
-		doReturn("randomString").when(pc).getProperty(Mockito.eq("sunbird.msg.91.auth"));
-		doCallRealMethod().when(pc).getProperty(AdditionalMatchers.not(Mockito.eq("sunbird.msg.91.auth")));
+//		doReturn("randomString").when(pc).getProperty(Mockito.eq("sunbird.msg.91.auth"));
+//		doCallRealMethod().when(pc).getProperty(AdditionalMatchers.not(Mockito.eq("sunbird.msg.91.auth")));
 	}
 
 }

--- a/sunbird-notification/src/test/resources/configuration.properties
+++ b/sunbird-notification/src/test/resources/configuration.properties
@@ -1,6 +1,6 @@
 sunbird.msg.91.country=91
 sunbird.msg.91.sender=TesSun
-sunbird.msg.91.auth=
+sunbird.msg.91.auth=randomstring
 sunbird.msg.91.method=POST
 sunbird.msg.91.route=4
 sunbird.msg.91.baseurl=http://api.msg91.com/


### PR DESCRIPTION
block. Hence changed the test-resources configuriton to include value
for sunbird.msg.91.auth