### PR TITLE
Isseus #SB-00 fix: adding page section parse failure check

### DIFF
--- a/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
+++ b/common-util/src/main/java/org/sunbird/common/responsecode/ResponseCode.java
@@ -739,7 +739,8 @@ public enum ResponseCode {
   errorInvalidParameterSize(
       ResponseMessage.Key.ERROR_INVALID_PARAMETER_SIZE,
       ResponseMessage.Message.ERROR_INVALID_PARAMETER_SIZE),
-
+  errorInvalidPageSection(
+      ResponseMessage.Key.INVALID_PAGE_SECTION, ResponseMessage.Message.INVALID_PAGE_SECTION),
   OK(200),
   CLIENT_ERROR(400),
   SERVER_ERROR(500),

--- a/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
+++ b/common-util/src/main/java/org/sunbird/common/responsecode/ResponseMessage.java
@@ -403,7 +403,9 @@ public interface ResponseMessage {
         "Something Went Wrong While Reading File. Please Check The File.";
     String ERR_FILE_NOT_FOUND = "File not found. Please select valid file and upload.";
     String ERROR_TB_UPDATE = "Error while updating the textbook";
-    String ERROR_INVALID_PARAMETER_SIZE = "Parameter {0} is of invalid size (expected: {1}, actual: {2}).";
+    String ERROR_INVALID_PARAMETER_SIZE =
+        "Parameter {0} is of invalid size (expected: {1}, actual: {2}).";
+    String INVALID_PAGE_SECTION = "Page section associated with this page is invalid.";
   }
 
   interface Key {
@@ -754,5 +756,6 @@ public interface ResponseMessage {
     String ERR_FILE_NOT_FOUND = "ERR_FILE_NOT_FOUND";
     String ERROR_TB_UPDATE = "ERROR_TB_UPDATE";
     String ERROR_INVALID_PARAMETER_SIZE = "ERROR_INVALID_PARAMETER_SIZE";
+    String INVALID_PAGE_SECTION = "INVALID_PAGE_SECTION";
   }
 }


### PR DESCRIPTION
Having check for page section invalid data. Some times page section is not in proper structure and during page assemble api call it's not able to parse it.