### PR TITLE
Issue#SB-13506 added Record Tracker to have resumable capability to s…

### DIFF
--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/ExternalIdDecryption.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/ExternalIdDecryption.java
@@ -17,18 +17,16 @@ public class ExternalIdDecryption {
    */
   public static void main(String[] args) throws Exception {
 
-//    try {
-//      RequestParams requestParams = prepareRequestParams();
-//      RequestParamValidator.getInstance(requestParams).validate();
-//      ConnectionFactory connectionFactory = new CassandraConnectionFactory();
-//      RecordProcessor recordProcessor = RecordProcessor.getInstance(connectionFactory, requestParams);
-//      recordProcessor.startProcessingExternalIds();
-//    } catch (Exception e) {
-//      throw new Exception(e.getMessage());
-//    }
-
-    prepareRequestParams();
-    System.out.println("+++++++++++++++++++++++++successfully Invoked++++++++++++++++++++++++++++");
+    try {
+      RequestParams requestParams = prepareRequestParams();
+      RequestParamValidator.getInstance(requestParams).validate();
+      ConnectionFactory connectionFactory = new CassandraConnectionFactory();
+      RecordProcessor recordProcessor = RecordProcessor.getInstance(connectionFactory, requestParams);
+      recordProcessor.startProcessingExternalIds();
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new Exception(e.getMessage());
+    }
   }
 
   /**

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/ExternalIdDecryption.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/ExternalIdDecryption.java
@@ -24,7 +24,6 @@ public class ExternalIdDecryption {
       RecordProcessor recordProcessor = RecordProcessor.getInstance(connectionFactory, requestParams);
       recordProcessor.startProcessingExternalIds();
     } catch (Exception e) {
-      e.printStackTrace();
       throw new Exception(e.getMessage());
     }
   }

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -13,6 +13,7 @@ import org.sunbird.decryptionUtil.connection.factory.ConnectionFactory;
 import org.sunbird.decryptionUtil.constants.DbColumnConstants;
 import org.sunbird.decryptionUtil.decryption.DecryptionService;
 import org.sunbird.decryptionUtil.decryption.DefaultDecryptionServiceImpl;
+import org.sunbird.decryptionUtil.tracker.RecordTracker;
 import org.sunbird.decryptionUtil.tracker.StatusTracker;
 
 import javax.crypto.BadPaddingException;
@@ -25,7 +26,7 @@ public class RecordProcessor extends StatusTracker {
     private RequestParams requestParams;
     private DecryptionService decryptionService;
     private static Logger logger = LoggerFactory.getLoggerInstance(RecordProcessor.class.getName());
-    public static final String successRecordFilePath="successRecords.txt";
+    public static final String successRecordFilePath = "successRecords.txt";
 
     /**
      * constructor for the class
@@ -33,7 +34,7 @@ public class RecordProcessor extends StatusTracker {
      * @param connectionFactory
      * @param requestParams
      */
-    private RecordProcessor(ConnectionFactory connectionFactory, RequestParams requestParams){
+    private RecordProcessor(ConnectionFactory connectionFactory, RequestParams requestParams) {
         this.connectionFactory = connectionFactory;
         this.requestParams = requestParams;
         this.connection =
@@ -53,7 +54,7 @@ public class RecordProcessor extends StatusTracker {
      * @return
      */
     public static RecordProcessor getInstance(
-            ConnectionFactory connectionFactory, RequestParams requestParams){
+            ConnectionFactory connectionFactory, RequestParams requestParams) {
         return new RecordProcessor(connectionFactory, requestParams);
     }
 
@@ -72,12 +73,12 @@ public class RecordProcessor extends StatusTracker {
 
     /**
      * this method will be used to process externalId
+     * this method will get the count of total number of records that need to be processed
      *
      * @return
      */
-    public void startProcessingExternalIds() {
-        List<User> usersList = getUserDataFromDbAsList();
-        logTotalRecords(usersList.size());
+    public void startProcessingExternalIds() throws IOException {
+        List<User> usersList = getRecordsToBeProcessed();
         usersList
                 .stream()
                 .forEach(
@@ -87,10 +88,10 @@ public class RecordProcessor extends StatusTracker {
                                 startTracingRecord(userObject.getUserId());
                                 User user = getDecryptedUserObject(userObject);
                                 performSequentialOperationOnRecord(user, compositeKeysMap);
-                                endTracingRecord(userObject.getUserId());
                             } catch (Exception e) {
                                 logExceptionOnProcessingRecord(compositeKeysMap);
                             }
+                            endTracingRecord(userObject.getUserId());
                         });
 
         connection.closeConnection();
@@ -144,4 +145,33 @@ public class RecordProcessor extends StatusTracker {
     }
 
 
+    private String getFormattedCompositeKeys(User user) {
+        return String.format("%s:%s:%s", user.getProvider(), user.getIdType(), user.getExternalId());
+    }
+
+    /**
+     * this methods
+     * @param preProcessedRecords
+     * @param totalRecords
+     * @return
+     */
+    private List<User> removePreProcessedRecordFromList(List<String> preProcessedRecords, List<User> totalRecords) {
+        logger.info("total records found preprocessed is " + preProcessedRecords.size());
+        logger.info("total records in db is " + totalRecords.size());
+        totalRecords.removeIf(user -> (preProcessedRecords.contains(getFormattedCompositeKeys(user))));
+        logTotalRecords(totalRecords.size());
+        return totalRecords;
+    }
+
+    /**
+     * this methods get the count of records from cassandra as totalUserList
+     * then this method will remove the preprocessed records from totalUserList.
+     * @return List<String>
+     * @throws IOException
+     */
+    private List<User> getRecordsToBeProcessed() throws IOException {
+        List<User> totalUsersList = getUserDataFromDbAsList();
+        List<String> preProcessedRecords = RecordTracker.getPreProcessedRecordsAsList();
+        return removePreProcessedRecordFromList(preProcessedRecords, totalUsersList);
+    }
 }

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -155,8 +155,6 @@ public class RecordProcessor extends StatusTracker {
      * @return
      */
     private List<User> removePreProcessedRecordFromList(List<String> preProcessedRecords, List<User> totalRecords) {
-        logger.info("total records found preprocessed is " + preProcessedRecords.size());
-        logger.info("total records in db is " + totalRecords.size());
         totalRecords.removeIf(user -> (preProcessedRecords.contains(getFormattedCompositeKeys(user))));
         logTotalRecords(totalRecords.size());
         return totalRecords;
@@ -170,7 +168,9 @@ public class RecordProcessor extends StatusTracker {
      */
     private List<User> getRecordsToBeProcessed() throws IOException {
         List<User> totalUsersList = getUserDataFromDbAsList();
+        logger.info("total records in db is " + totalUsersList.size());
         List<String> preProcessedRecords = RecordTracker.getPreProcessedRecordsAsList();
+        logger.info("total records found preprocessed is " + preProcessedRecords.size());
         return removePreProcessedRecordFromList(preProcessedRecords, totalUsersList);
     }
 }

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -26,7 +26,6 @@ public class RecordProcessor extends StatusTracker {
     private RequestParams requestParams;
     private DecryptionService decryptionService;
     private static Logger logger = LoggerFactory.getLoggerInstance(RecordProcessor.class.getName());
-    public static final String successRecordFilePath = "successRecords.txt";
 
     /**
      * constructor for the class
@@ -109,8 +108,8 @@ public class RecordProcessor extends StatusTracker {
     private User getDecryptedUserObject(User userObject) throws BadPaddingException, IOException, IllegalBlockSizeException {
         String externalId = decryptionService.decryptData(userObject.getExternalId());
         String originalExternalId = decryptionService.decryptData(userObject.getOriginalExternalId());
-        userObject.setExternalId(externalId.concat("1"));
-        userObject.setOriginalExternalId(originalExternalId.concat("1"));
+        userObject.setExternalId(externalId);
+        userObject.setOriginalExternalId(originalExternalId);
         return userObject;
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/constants/EnvConstants.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/constants/EnvConstants.java
@@ -11,4 +11,5 @@ public class EnvConstants {
     public static final String SUNBIRD_CASSANDRA_KEYSPACENAME = "sunbird_cassandra_keyspace";
     public static final String SUNBIRD_CASSANDRA_PORT = "sunbird_cassandra_port";
     public static final String SUNBIRD_ENCRYPTION_KEY = "sunbird_encryption_key";
+    public static final String PRE_PROCESSED_RECORDS_FILE="preProcessedRecords.txt";
 }

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/RecordTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/RecordTracker.java
@@ -1,0 +1,61 @@
+package org.sunbird.decryptionUtil.tracker;
+
+import org.apache.log4j.Logger;
+import org.sunbird.decryptionUtil.LoggerFactory;
+import org.sunbird.decryptionUtil.constants.EnvConstants;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * this class will be used to read records which are pre processed
+ * and list of preprocessed records is present isn preProcessedRecords.txt
+ */
+public class RecordTracker {
+
+    private static Logger logger = LoggerFactory.getLoggerInstance(RecordTracker.class.getName());
+    public static List<String> getPreProcessedRecordsAsList() throws IOException {
+        List<String> successfullRecordsList = new ArrayList<>();
+        File file = new File(EnvConstants.PRE_PROCESSED_RECORDS_FILE);
+        printFilelastModified(file);
+        if (file.exists()) {
+            successfullRecordsList = readFileGetList(file);
+        } else {
+            file.createNewFile();
+        }
+        return successfullRecordsList;
+    }
+
+
+    /**
+     * this method will remove the last index value from the list
+     * since it may be possible that the last value may be not fully written by writer..
+     * @param file
+     * @return
+     */
+    private static List<String> readFileGetList(File file) {
+        List<String> preProcessedRecords = new ArrayList<>();
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+            String line;
+            while ((line = br.readLine()) != null) {
+                preProcessedRecords.add(line);
+            }
+        } catch (IOException e) {
+            logger.error(String.format("no file found named %s creating it again....",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
+        }
+        preProcessedRecords.remove(preProcessedRecords.size() - 1);
+        return preProcessedRecords;
+    }
+
+    private static void printFilelastModified(File file) {
+        String dateFormat="MM/dd/yyyy HH:mm:ss";
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        logger.info(String.format("%s last modified at %s", EnvConstants.PRE_PROCESSED_RECORDS_FILE,sdf.format(file.lastModified())));
+    }
+}

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -68,9 +68,9 @@ public class StatusTracker {
             } else {
                 fw = new FileWriter(EnvConstants.PRE_PROCESSED_RECORDS_FILE);
             }
-
         } catch (Exception e) {
-            logger.error(String.format("%s:%s:error occurred while writing preProcessed records to file",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile"));
+            logger.error(String.format("%s:%s:error occurred while writing preProcessed records to file with message %s",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile",e.getMessage()));
+            System.exit(0);
         }
     }
 
@@ -78,7 +78,7 @@ public class StatusTracker {
         try {
             fw.close();
         } catch (Exception e) {
-            logger.error(String.format("%s:%s:error occurred while closing connection to  file %s",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
+            logger.error(String.format("%s error occurred while closing connection to  file %s","writeSuccessRecordToFile",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
         }
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -3,6 +3,7 @@ package org.sunbird.decryptionUtil.tracker;
 import org.apache.log4j.Logger;
 import org.sunbird.decryptionUtil.LoggerFactory;
 import org.sunbird.decryptionUtil.constants.DbColumnConstants;
+import org.sunbird.decryptionUtil.constants.EnvConstants;
 
 import java.io.FileWriter;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class StatusTracker {
     }
 
     public static void endTracingRecord(String id) {
-        logger.info("================================ UserId: " + id + " ended ===========================================");
+        logger.info("================================ UserId: " + id + " ended ===========================================\n");
     }
 
     public static void logQuery(String query) {
@@ -25,41 +26,47 @@ public class StatusTracker {
     }
 
     public static void logFailedRecord(Map<String, String> compositeKeysMap) {
-        logger.info(String.format("Record Failed with externalId: %s provider: %s and idType: %s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.info(String.format("Record Failed with externalId:%s provider:%s and idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logSuccessRecord(String externalId, String provider, String idType) {
-        logger.info(String.format("Record updation success with externalId: %s provider: %s and idType: %s", externalId, provider, idType));
+        logger.info(String.format("Record updation success with externalId:%s provider:%s and idType:%s", externalId, provider, idType));
         writeSuccessRecordToFile(provider,idType,externalId);
     }
 
     public static void logDeletedRecord(Map<String, String> compositeKeysMap) {
-        logger.info(String.format("Record deleted with externalId: %s provider: %s and idType: %s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.info(String.format("Record deleted with externalId:%s provider:%s and idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logInsertedRecord(String externalId, String provider, String idType) {
-        logger.info(String.format("Record insertion success with externalId: %s provider: %s and idType: %s", externalId, provider, idType));
+        logger.info(String.format("Record insertion success with externalId:%s provider:%s and idType:%s", externalId, provider, idType));
     }
 
     public static void logFailedDeletedRecord(Map<String, String> compositeKeysMap) {
-        logger.info(String.format("Record failed to delete with externalId: %s provider: %s and idType: %s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.info(String.format("Record failed to delete with externalId: %s provider:%s and idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logExceptionOnProcessingRecord(Map<String, String> compositeKeysMap) {
-        logger.error(String.format("error occurred while processing record with externalId: %s provider: %s idType: %s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.error(String.format("may be this record is preprocessed but cant detect by the service or error occurred while decrypting while processing record with externalId:%s provider:%s idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logTotalRecords(long count) {
         logger.error(String.format("================================ Total Records to be processed: %s ========================================", count));
     }
+    public static void logPreProcessedRecord(Map<String, String> compositeKeysMap) {
+        logger.error(String.format("Record with  externalId:%s provider:%s idType:%s pre processed", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+    }
+
 
 
     public static void writeSuccessRecordToFile(String provider, String idType, String externalId) {
         try {
             if (fw != null) {
                 fw.write(String.format("%s:%s:%s", provider, idType, externalId));
+                fw.write("\n");
+                fw.flush();
             } else {
-                fw = new FileWriter("successRecords.txt");
+                fw = new FileWriter(EnvConstants.PRE_PROCESSED_RECORDS_FILE);
             }
 
         } catch (Exception e) {

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -47,7 +47,7 @@ public class StatusTracker {
     }
 
     public static void logExceptionOnProcessingRecord(Map<String, String> compositeKeysMap) {
-        logger.error(String.format("may be this record is preprocessed but cant detect by the service or error occurred while decrypting while processing record with externalId:%s provider:%s idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.error(String.format("Error occurred in  decrypting  record with externalId:%s provider:%s idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logTotalRecords(long count) {
@@ -70,6 +70,7 @@ public class StatusTracker {
             }
 
         } catch (Exception e) {
+            logger.error(String.format("%s:%s:error occurred while writing preProcessed records to file",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile"));
         }
     }
 
@@ -77,6 +78,7 @@ public class StatusTracker {
         try {
             fw.close();
         } catch (Exception e) {
+            logger.error(String.format("%s:%s:error occurred while closing connection to  file %s",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
         }
     }
 

--- a/decryption-util/src/main/resources/log4j.properties
+++ b/decryption-util/src/main/resources/log4j.properties
@@ -2,9 +2,9 @@
 log4j.rootLogger=INFO, file, stdout
 # configuration to print into file
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.File=ExternalIdDecryption.log
-log4j.appender.file.MaxFileSize=20MB
-log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.File=decryptionUtils.log
+log4j.appender.file.MaxFileSize=100MB
+log4j.appender.file.MaxBackupIndex=15
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
 # configuration to print on console


### PR DESCRIPTION
Ticket Ref: [SB-13506](https://project-sunbird.atlassian.net/browse/SB-13506)
1: This script is used to decrypt the user externalId and commit the user decrypted record in usr_external_idenity table.
2: it has ConnectionFactory which makes connection to the cassandra database.
3: Read all user from usr_external_identity in one go.
4: Take the decision whether the record needs to be processed or it's been processed earlier, it has the capability to resume.
5: decrypt the externalId and orignalExternalId
6: insert the user data in decrypted format.
7: delete the respective user from the database.