### PR TITLE
SB-13506 Decrypt userExternalId even when OrigExternalId is null

### DIFF
--- a/decryption-util/README.md
+++ b/decryption-util/README.md
@@ -24,4 +24,4 @@
    - verify the column externalid, originalexternalid should be in decrypted format.
    -  Run the Query: SELECT COUNT(*) FROM sunbird.usr_external_identity;  
    - count after running and before running should matches.
-   - At the end of the run the program will generate the file named ```preProcessecRecords.txt``` where its easy to identify the records which are successfully processed
+   - At the end of the run the program will generate the file named ```preProcessecRecords.txt``` which has provider,idType,externalId in format ```provider:idtype:externalid``` so  its easy to identify the records which are successfully processed...

--- a/decryption-util/README.md
+++ b/decryption-util/README.md
@@ -24,3 +24,4 @@
    - verify the column externalid, originalexternalid should be in decrypted format.
    -  Run the Query: SELECT COUNT(*) FROM sunbird.usr_external_identity;  
    - count after running and before running should matches.
+   - At the end of the run the program will generate the file named ```preProcessecRecords.txt``` where its easy to identify the records which are successfully processed

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -89,7 +89,6 @@ public class RecordProcessor extends StatusTracker {
                                 startTracingRecord(userObject.getUserId());
                                     if (StringUtils.isEmpty(userObject.getExternalId()) || StringUtils.isEmpty(userObject.getOriginalExternalId())) {
                                     logCorruptedRecord(compositeKeysMap, userObject.getOriginalExternalId());
-                                    deleteCorruptedRecord(compositeKeysMap);
                                 } else {
                                     User user = getDecryptedUserObject(userObject);
                                     performSequentialOperationOnRecord(user, compositeKeysMap);
@@ -184,13 +183,4 @@ public class RecordProcessor extends StatusTracker {
         return removePreProcessedRecordFromList(preProcessedRecords, totalUsersList);
     }
 
-    private void deleteCorruptedRecord(Map<String, String> compositeKeysMap) {
-        boolean isCorruptRecordDeleted = connection.deleteRecord(compositeKeysMap);
-        if (isCorruptRecordDeleted) {
-            logDeletedRecord(compositeKeysMap);
-        } else {
-            logFailedDeletedRecord(compositeKeysMap);
-        }
-
-    }
 }

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -108,6 +108,15 @@ public class RecordProcessor extends StatusTracker {
         return compositeKeysMap;
     }
 
+    /**
+     * this method is responsible to decrypt the externalId and originalExternalId
+     * if originalExternalId is null or absent it will ignore it and decrypt only externalId.
+     * @param userObject
+     * @return userObject
+     * @throws BadPaddingException
+     * @throws IOException
+     * @throws IllegalBlockSizeException
+     */
     private User getDecryptedUserObject(User userObject) throws BadPaddingException, IOException, IllegalBlockSizeException {
         String externalId = decryptionService.decryptData(userObject.getExternalId());
         if (StringUtils.isNotBlank(userObject.getOriginalExternalId())) {
@@ -121,7 +130,7 @@ public class RecordProcessor extends StatusTracker {
     /**
      * this method will perform sequential operation of db records
      * - generate insert query
-     * - decrypt the externalIds and orignalExternalIds
+     * - decrypt the externalIds and originalExternalIds
      * - insert record
      * - insert Record passes will then delete the record...
      *

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -88,7 +88,7 @@ public class RecordProcessor extends StatusTracker {
                             try {
                                 startTracingRecord(userObject.getUserId());
                                 if (TextUtils.isEmpty(userObject.getExternalId()) || TextUtils.isEmpty(userObject.getOriginalExternalId())) {
-                                    logCorruptedRecord(compositeKeysMap,userObject.getOriginalExternalId());
+                                    logCorruptedRecord(compositeKeysMap, userObject.getOriginalExternalId());
                                     deleteCorruptedRecord(compositeKeysMap);
                                 } else {
                                     User user = getDecryptedUserObject(userObject);

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -88,6 +88,7 @@ public class RecordProcessor extends StatusTracker {
                                 User user = getDecryptedUserObject(userObject);
                                 performSequentialOperationOnRecord(user, compositeKeysMap);
                             } catch (Exception e) {
+                                connection.deleteRecord(compositeKeysMap);
                                 logExceptionOnProcessingRecord(compositeKeysMap);
                             }
                             finally {

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -87,12 +87,8 @@ public class RecordProcessor extends StatusTracker {
                             Map<String, String> compositeKeysMap = getCompositeKeysMap(userObject);
                             try {
                                 startTracingRecord(userObject.getUserId());
-                                    if (StringUtils.isEmpty(userObject.getExternalId()) || StringUtils.isEmpty(userObject.getOriginalExternalId())) {
-                                    logCorruptedRecord(compositeKeysMap, userObject.getOriginalExternalId());
-                                } else {
-                                    User user = getDecryptedUserObject(userObject);
-                                    performSequentialOperationOnRecord(user, compositeKeysMap);
-                                }
+                                User user = getDecryptedUserObject(userObject);
+                                performSequentialOperationOnRecord(user, compositeKeysMap);
                             } catch (Exception e) {
                                 logExceptionOnProcessingRecord(compositeKeysMap);
                             } finally {
@@ -114,9 +110,11 @@ public class RecordProcessor extends StatusTracker {
 
     private User getDecryptedUserObject(User userObject) throws BadPaddingException, IOException, IllegalBlockSizeException {
         String externalId = decryptionService.decryptData(userObject.getExternalId());
-        String originalExternalId = decryptionService.decryptData(userObject.getOriginalExternalId());
+        if (StringUtils.isNotBlank(userObject.getOriginalExternalId())) {
+            String originalExternalId = decryptionService.decryptData(userObject.getOriginalExternalId());
+            userObject.setOriginalExternalId(originalExternalId);
+        }
         userObject.setExternalId(externalId);
-        userObject.setOriginalExternalId(originalExternalId);
         return userObject;
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.util.TextUtils;
 import org.apache.log4j.Logger;
 import org.sunbird.decryptionUtil.connection.Connection;
 import org.sunbird.decryptionUtil.connection.factory.ConnectionFactory;

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/RecordProcessor.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.util.TextUtils;
 import org.apache.log4j.Logger;
 import org.sunbird.decryptionUtil.connection.Connection;
@@ -87,7 +88,7 @@ public class RecordProcessor extends StatusTracker {
                             Map<String, String> compositeKeysMap = getCompositeKeysMap(userObject);
                             try {
                                 startTracingRecord(userObject.getUserId());
-                                if (TextUtils.isEmpty(userObject.getExternalId()) || TextUtils.isEmpty(userObject.getOriginalExternalId())) {
+                                    if (StringUtils.isEmpty(userObject.getExternalId()) || StringUtils.isEmpty(userObject.getOriginalExternalId())) {
                                     logCorruptedRecord(compositeKeysMap, userObject.getOriginalExternalId());
                                     deleteCorruptedRecord(compositeKeysMap);
                                 } else {

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/RecordTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/RecordTracker.java
@@ -49,7 +49,6 @@ public class RecordTracker {
         } catch (IOException e) {
             logger.error(String.format("no file found named %s creating it again....",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
         }
-        preProcessedRecords.remove(preProcessedRecords.size() - 1);
         return preProcessedRecords;
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -58,9 +58,8 @@ public class StatusTracker {
         logger.error(String.format("Record with  externalId:%s provider:%s idType:%s pre processed", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
     public static void logCorruptedRecord(Map<String, String> compositeKeysMap,String orignalExternalId) {
-        logger.info(String.format("corrupted Record found with provider='%s' AND idtype='%s' AND externalid='%s AND orignalexternalid='%s''", compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType),compositeKeysMap.get(DbColumnConstants.externalId),orignalExternalId));
+        logger.info(String.format("SKIPPING the record because corrupted Record found with provider='%s' AND idtype='%s' AND externalid='%s' AND orignalexternalid='%s'", compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType),compositeKeysMap.get(DbColumnConstants.externalId),orignalExternalId));
     }
-
 
     public static void writeSuccessRecordToFile(String provider, String idType, String externalId) {
         try {

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -14,11 +14,11 @@ public class StatusTracker {
     static FileWriter fw;
 
     public static void startTracingRecord(String id) {
-        logger.info("================================ UserId: " + id + " started===========================================");
+        logger.info("UserId: " + id + " started...");
     }
 
     public static void endTracingRecord(String id) {
-        logger.info("================================ UserId: " + id + " ended ===========================================\n");
+        logger.info("UserId: " + id + " ended...\n");
     }
 
     public static void logQuery(String query) {

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -82,8 +82,7 @@ public class StatusTracker {
                 fw.close();
             }
         } catch (Exception e) {
-            e.printStackTrace();
-            logger.error(String.format("%s error occurred while closing connection to  file %s", "writeSuccessRecordToFile", EnvConstants.PRE_PROCESSED_RECORDS_FILE));
+            logger.error(String.format("%s error occurred while closing connection to file %s and error is %s", "writeSuccessRecordToFile", EnvConstants.PRE_PROCESSED_RECORDS_FILE,e.getMessage()));
         }
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -31,7 +31,7 @@ public class StatusTracker {
 
     public static void logSuccessRecord(String externalId, String provider, String idType) {
         logger.info(String.format("Record updation success with externalId:%s provider:%s and idType:%s", externalId, provider, idType));
-        writeSuccessRecordToFile(provider,idType,externalId);
+        writeSuccessRecordToFile(provider, idType, externalId);
     }
 
     public static void logDeletedRecord(Map<String, String> compositeKeysMap) {
@@ -47,16 +47,19 @@ public class StatusTracker {
     }
 
     public static void logExceptionOnProcessingRecord(Map<String, String> compositeKeysMap) {
-        logger.error(String.format("Error occurred in  decrypting  record with externalId:%s provider:%s idType:%s REMOVING record from database......", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.error(String.format("Error occurred in  decrypting  record with externalId:%s provider:%s idType:%s ", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logTotalRecords(long count) {
         logger.info(String.format("================================ Total Records to be processed: %s ========================================", count));
     }
+
     public static void logPreProcessedRecord(Map<String, String> compositeKeysMap) {
         logger.error(String.format("Record with  externalId:%s provider:%s idType:%s pre processed", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
-
+    public static void logCorruptedRecord(Map<String, String> compositeKeysMap,String orignalExternalId) {
+        logger.info(String.format("corrupted Record found with provider='%s' AND idtype='%s' AND externalid='%s AND orignalexternalid='%s''", compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType),compositeKeysMap.get(DbColumnConstants.externalId),orignalExternalId));
+    }
 
 
     public static void writeSuccessRecordToFile(String provider, String idType, String externalId) {
@@ -69,16 +72,19 @@ public class StatusTracker {
                 fw = new FileWriter(EnvConstants.PRE_PROCESSED_RECORDS_FILE);
             }
         } catch (Exception e) {
-            logger.error(String.format("%s:%s:error occurred while writing preProcessed records to file with message %s",StatusTracker.class.getSimpleName(),"writeSuccessRecordToFile",e.getMessage()));
+            logger.error(String.format("%s:%s:error occurred while writing preProcessed records to file with message %s", StatusTracker.class.getSimpleName(), "writeSuccessRecordToFile", e.getMessage()));
             System.exit(0);
         }
     }
 
     public static void closeWriterConnection() {
         try {
-            fw.close();
+            if (fw != null) {
+                fw.close();
+            }
         } catch (Exception e) {
-            logger.error(String.format("%s error occurred while closing connection to  file %s","writeSuccessRecordToFile",EnvConstants.PRE_PROCESSED_RECORDS_FILE));
+            e.printStackTrace();
+            logger.error(String.format("%s error occurred while closing connection to  file %s", "writeSuccessRecordToFile", EnvConstants.PRE_PROCESSED_RECORDS_FILE));
         }
     }
 

--- a/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
+++ b/decryption-util/src/main/java/org/sunbird/decryptionUtil/tracker/StatusTracker.java
@@ -47,11 +47,11 @@ public class StatusTracker {
     }
 
     public static void logExceptionOnProcessingRecord(Map<String, String> compositeKeysMap) {
-        logger.error(String.format("Error occurred in  decrypting  record with externalId:%s provider:%s idType:%s", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
+        logger.error(String.format("Error occurred in  decrypting  record with externalId:%s provider:%s idType:%s REMOVING record from database......", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));
     }
 
     public static void logTotalRecords(long count) {
-        logger.error(String.format("================================ Total Records to be processed: %s ========================================", count));
+        logger.info(String.format("================================ Total Records to be processed: %s ========================================", count));
     }
     public static void logPreProcessedRecord(Map<String, String> compositeKeysMap) {
         logger.error(String.format("Record with  externalId:%s provider:%s idType:%s pre processed", compositeKeysMap.get(DbColumnConstants.externalId), compositeKeysMap.get(DbColumnConstants.provider), compositeKeysMap.get(DbColumnConstants.idType)));


### PR DESCRIPTION
<b>Ticket Ref: </b> [SB-13506 ](https://project-sunbird.atlassian.net/browse/SB-13506)
1: Earlier release the case for corrupted data not considered, it may be possible in some case originalExternalId is null or blank.
2: so if orignalExternalId is blank or null we will only decrypt the externalId  and ignore orignalExternalId
3: if both the orignalExternalId and externalId are present and then while decrypting those ids cause exception, then that particular record will be a failure record for us...