### PR TITLE
Issue #SC-1192 feat: Audit event call is not queued

### DIFF
--- a/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -915,6 +915,6 @@ public final class JsonKey {
   public static final String RECIPIENT_PHONES = "recipientPhones";
   public static final String TCP = "tcp";
   public static final String REST = "rest";
-
+  public static final String SUNBIRD_AUDIT_EVNET_BATCH_ALLOWED = "sunbird_audit_event_batch_allowed";
   private JsonKey() {}
 }

--- a/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/TelemetryFlush.java
+++ b/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/TelemetryFlush.java
@@ -79,7 +79,7 @@ public class TelemetryFlush {
     }
   }
 
-  private Request createTelemetryRequest(List<String> eventList) {
+  public Request createTelemetryRequest(List<String> eventList) {
     Request req = null;
     try {
       List<Map<String, Object>> jsonList =

--- a/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/WriteEventHandler.java
+++ b/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/WriteEventHandler.java
@@ -1,12 +1,15 @@
 package org.sunbird.telemetry.util;
 
 import com.lmax.disruptor.EventHandler;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.sunbird.common.models.util.JsonKey;
 import org.sunbird.common.models.util.LoggerEnum;
 import org.sunbird.common.models.util.ProjectLogger;
+import org.sunbird.common.models.util.ProjectUtil;
 import org.sunbird.common.request.Request;
 import org.sunbird.telemetry.collector.TelemetryAssemblerFactory;
 import org.sunbird.telemetry.collector.TelemetryDataAssembler;
@@ -23,7 +26,7 @@ public class WriteEventHandler implements EventHandler<Request> {
   private TelemetryFlush telemetryFlush = TelemetryFlush.getInstance();
   private TelemetryDataAssembler telemetryDataAssembler = TelemetryAssemblerFactory.get();
   private TelemetryObjectValidator telemetryObjectValidator = new TelemetryObjectValidatorV3();
-
+  private SunbirdTelemetryEventConsumer consumer = SunbirdTelemetryEventConsumer.getInstance();
   @Override
   public void onEvent(Request request, long l, boolean b) throws Exception {
     try {
@@ -103,7 +106,6 @@ public class WriteEventHandler implements EventHandler<Request> {
   }
 
   private boolean processAuditEvent(Request request) {
-
     boolean success = false;
     Map<String, Object> context = (Map<String, Object>) request.get(JsonKey.CONTEXT);
     Map<String, Object> targetObject = (Map<String, Object>) request.get(JsonKey.TARGET_OBJECT);
@@ -115,6 +117,15 @@ public class WriteEventHandler implements EventHandler<Request> {
     String telemetry = telemetryDataAssembler.audit(context, params);
     if (StringUtils.isNotBlank(telemetry) && telemetryObjectValidator.validateAudit(telemetry)) {
       telemetryFlush.flushTelemetry(telemetry);
+      if (!Boolean.parseBoolean(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_AUDIT_EVNET_BATCH_ALLOWED))) {
+			ProjectLogger.log("WriteEventHandler:processLogEvent: Audit Event is going to be processed = ", LoggerEnum.INFO.name());
+			List<String> list = new ArrayList<String>();
+			list.add(telemetry);
+			Request auditRequest = telemetryFlush.createTelemetryRequest(list);
+			consumer.consume(auditRequest);
+		} else {
+           telemetryFlush.flushTelemetry(telemetry);
+         }
       success = true;
     } else {
       ProjectLogger.log(

--- a/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/WriteEventHandler.java
+++ b/sunbird-platform-core/common-util/src/main/java/org/sunbird/telemetry/util/WriteEventHandler.java
@@ -116,7 +116,6 @@ public class WriteEventHandler implements EventHandler<Request> {
     params.put(JsonKey.CORRELATED_OBJECTS, correlatedObjects);
     String telemetry = telemetryDataAssembler.audit(context, params);
     if (StringUtils.isNotBlank(telemetry) && telemetryObjectValidator.validateAudit(telemetry)) {
-      telemetryFlush.flushTelemetry(telemetry);
       if (!Boolean.parseBoolean(ProjectUtil.getConfigValue(JsonKey.SUNBIRD_AUDIT_EVNET_BATCH_ALLOWED))) {
 			ProjectLogger.log("WriteEventHandler:processLogEvent: Audit Event is going to be processed = ", LoggerEnum.INFO.name());
 			List<String> list = new ArrayList<String>();

--- a/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
+++ b/sunbird-platform-core/common-util/src/main/resources/externalresource.properties
@@ -168,3 +168,4 @@ sunbird_redis_host=127.0.0.1
 sunbird_redis_scan_interval=2000
 sunbird_cache_enable=false
 sunbird_redis_connection_pool_size=250
+sunbird_audit_event_batch_allowed=false


### PR DESCRIPTION
*  Allowing Audit event telemetry to send to telemetry service without queuing.
* By default this option is enable now but we can desiable is by putting env "sunbird_audit_event_batch_allowed" as true.