### PR TITLE
SC-1253 Enhancing Search API

### DIFF
--- a/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
+++ b/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
@@ -217,7 +217,7 @@ public class ElasticSearchHelper {
       query = getTermQueryFromList(val, key, query, constraintsMap);
     } else if (val instanceof Map) {
        if(key.equalsIgnoreCase(JsonKey.ES_OR_OPERATION)){
-         createEsOrFilterQuery((Map<String,Object>)val,query,constraintsMap);
+         query.must(createEsOrFilterQuery((Map<String,Object>)val,constraintsMap));
        }
        else {
          query = getTermQueryFromMap(val, key, query, constraintsMap);
@@ -270,7 +270,8 @@ public class ElasticSearchHelper {
     return query;
   }
 
-    private static BoolQueryBuilder createEsOrFilterQuery(Map<String,Object>orFilters, BoolQueryBuilder query, Map<String, Float> constraintsMap) {
+    private static BoolQueryBuilder createEsOrFilterQuery(Map<String,Object>orFilters,  Map<String, Float> constraintsMap) {
+        BoolQueryBuilder query=new BoolQueryBuilder();
     ProjectLogger.log(
             "ElasticSearchHelper:createEsOrFilterQuery: method started ", LoggerEnum.INFO.name());
     ProjectLogger.log("Got data in or filters query"+Collections.singleton(orFilters.toString()),LoggerEnum.INFO.name());

--- a/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
+++ b/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
@@ -217,7 +217,7 @@ public class ElasticSearchHelper {
       query = getTermQueryFromList(val, key, query, constraintsMap);
     } else if (val instanceof Map) {
        if(key.equalsIgnoreCase(JsonKey.ES_OR_OPERATION)){
-         query.must(createEsOrFilterQuery((Map<String,Object>)val,constraintsMap));
+         query.must(createEsORFilterQuery((Map<String,Object>)val));
        }
        else {
          query = getTermQueryFromMap(val, key, query, constraintsMap);
@@ -270,16 +270,15 @@ public class ElasticSearchHelper {
     return query;
   }
 
-    private static BoolQueryBuilder createEsOrFilterQuery(Map<String,Object>orFilters,  Map<String, Float> constraintsMap) {
+    private static BoolQueryBuilder createEsORFilterQuery(Map<String,Object>orFilters) {
         BoolQueryBuilder query=new BoolQueryBuilder();
     ProjectLogger.log(
-            "ElasticSearchHelper:createEsOrFilterQuery: method started ", LoggerEnum.INFO.name());
-    ProjectLogger.log("Got data in or filters query"+Collections.singleton(orFilters.toString()),LoggerEnum.INFO.name());
+            "ElasticSearchHelper:createEsORFilterQuery:method started ", LoggerEnum.INFO.name());
     for (Map.Entry<String,Object>mp:orFilters.entrySet()){
-      query.should(QueryBuilders.termQuery(mp.getKey()+RAW_APPEND , mp.getValue()));
+      query.should(QueryBuilders.termQuery(mp.getKey()+RAW_APPEND , ((String)mp.getValue()).toLowerCase()));
       }
     ProjectLogger.log(
-            "ElasticSearchHelper:createEsOrFilterQuery: method end ", LoggerEnum.INFO.name());
+            "ElasticSearchHelper:createEsORFilterQuery:method end ", LoggerEnum.INFO.name());
     return query;
   }
 

--- a/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
+++ b/sunbird-es-utils/src/main/java/org/sunbird/common/ElasticSearchHelper.java
@@ -216,7 +216,12 @@ public class ElasticSearchHelper {
     if (val instanceof List && val != null) {
       query = getTermQueryFromList(val, key, query, constraintsMap);
     } else if (val instanceof Map) {
-      query = getTermQueryFromMap(val, key, query, constraintsMap);
+       if(key.equalsIgnoreCase(JsonKey.ES_OR_OPERATION)){
+         createEsOrFilterQuery((Map<String,Object>)val,query,constraintsMap);
+       }
+       else {
+         query = getTermQueryFromMap(val, key, query, constraintsMap);
+       }
     } else if (val instanceof String) {
       query.must(
           createTermQuery(key + RAW_APPEND, ((String) val).toLowerCase(), constraintsMap.get(key)));
@@ -227,6 +232,7 @@ public class ElasticSearchHelper {
         "ElasticSearchHelper:createFilterESOpperation: method end ", LoggerEnum.INFO.name());
     return query;
   }
+
 
   /**
    * This method returns termQuery if any present in map provided
@@ -261,6 +267,18 @@ public class ElasticSearchHelper {
     ProjectLogger.log(
         "ElasticSearchHelper:getTermQueryFromMap: method end ", LoggerEnum.INFO.name());
 
+    return query;
+  }
+
+    private static BoolQueryBuilder createEsOrFilterQuery(Map<String,Object>orFilters, BoolQueryBuilder query, Map<String, Float> constraintsMap) {
+    ProjectLogger.log(
+            "ElasticSearchHelper:createEsOrFilterQuery: method started ", LoggerEnum.INFO.name());
+    ProjectLogger.log("Got data in or filters query"+Collections.singleton(orFilters.toString()),LoggerEnum.INFO.name());
+    for (Map.Entry<String,Object>mp:orFilters.entrySet()){
+      query.should(QueryBuilders.termQuery(mp.getKey()+RAW_APPEND , mp.getValue()));
+      }
+    ProjectLogger.log(
+            "ElasticSearchHelper:createEsOrFilterQuery: method end ", LoggerEnum.INFO.name());
     return query;
   }
 
@@ -350,6 +368,7 @@ public class ElasticSearchHelper {
       return QueryBuilders.termsQuery(key, (values).stream().toArray(Object[]::new));
     }
   }
+
 
   /**
    * This method returns RangeQueryBuilder with boosts if any provided

--- a/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
+++ b/sunbird-platform-core/common-util/src/main/java/org/sunbird/common/models/util/JsonKey.java
@@ -918,5 +918,6 @@ public final class JsonKey {
   public static final String SUNBIRD_AUDIT_EVNET_BATCH_ALLOWED = "sunbird_audit_event_batch_allowed";
   public static final String PREV_USED_EMAIL ="prevusedemail";
   public static final String PREV_USED_PHONE ="prevusedphone";
+  public static final String ES_OR_OPERATION = "$or";
   private JsonKey() {}
 }


### PR DESCRIPTION
<b>Ticket Ref: </b> [SC-1253](https://project-sunbird.atlassian.net/browse/SC-1253)
1: Search API support $or inside filter now
2: request body
>   {
    "request": {
        "filters": {
        "email":"test1@gmail.com",
        	"$or":{
        		"firstName":"xyx",
         		 "phone":"8318XXXXX"
        	}}}

3: Referred Document:[ DOCS](https://www.elastic.co/guide/en/elasticsearch/reference/6.3/query-dsl-bool-query.html), [StackOverflow Link](https://stackoverflow.com/questions/28538760/elasticsearch-bool-query-combine-must-with-or/40755927)
4: In ElasticSearchHelper: if in filters we found that $or is present we make another QueryBoolBuilder object and add that as a must in previous QueryBuilderObject.