### PR TITLE
SC-1878 Fix for self declared channel mapped to different states

### DIFF
--- a/externalId-migration-util/src/main/java/org/sunbird/migration/CassandraHelper.java
+++ b/externalId-migration-util/src/main/java/org/sunbird/migration/CassandraHelper.java
@@ -95,19 +95,19 @@ public class CassandraHelper {
     return query.toString();
   }
 
-  public static String getInsertRecordQueryForUser(User user, Map<String, String> orgProviderMap) {
+  public static String getInsertRecordQueryForUser(User user, String provider) {
     return String.format(
         "INSERT INTO sunbird.usr_external_identity (provider, idtype, externalid, createdby, createdon, lastupdatedby, lastupdatedon, originalexternalid, originalidtype, originalprovider, userid) VALUES('%s','%s', '%s', '%s', %s,'%s',%s,'%s','%s','%s','%s');",
-        orgProviderMap.get(user.getOriginalProvider()),
-        orgProviderMap.get(user.getOriginalIdType()),
+        provider,
+        provider,
         user.getExternalId(),
         user.getCreatedBy(),
         getTimeStampFromDate(user.getCreatedOn()).getTime(),
         user.getLastUpdatedBy(),
         getLastUpdatedOn(),
         user.getOriginalExternalId(),
-        orgProviderMap.get(user.getOriginalIdType()),
-        orgProviderMap.get(user.getOriginalProvider()),
+        provider,
+        provider,
         user.getUserId());
   }
 

--- a/externalId-migration-util/src/main/java/org/sunbird/migration/RecordProcessor.java
+++ b/externalId-migration-util/src/main/java/org/sunbird/migration/RecordProcessor.java
@@ -259,11 +259,11 @@ public class RecordProcessor extends StatusTracker {
         // info in  lower case
         String provider = null;
         for (User user : users) {
-          provider = user.getOriginalProvider();
-          if (null == provider) {
-            break;
-          }
           if (null != user.getOriginalIdType() && user.getOriginalIdType().contains("declared-")) {
+            provider = user.getOriginalProvider();
+            if (null == provider) {
+              break;
+            }
             userInfo.put(user.getOriginalIdType(), user.getOriginalExternalId());
           }
         }

--- a/externalId-migration-util/src/main/java/org/sunbird/migration/RecordProcessor.java
+++ b/externalId-migration-util/src/main/java/org/sunbird/migration/RecordProcessor.java
@@ -198,6 +198,7 @@ public class RecordProcessor extends StatusTracker {
     try {
       String provider = orgIdProviderMap.get(stateUser.getOriginalProvider());
       if (null == provider) {
+        logger.info(String.format("Checking channel: %s with lower case in state users", provider));
         provider = orgIdProviderMap.get(stateUser.getOriginalProvider().toLowerCase());
       }
       if (null != provider) {
@@ -332,6 +333,8 @@ public class RecordProcessor extends StatusTracker {
     try {
       String provider = orgProviderMap.get(userDeclareEntity.getProvider());
       if (null == provider) {
+        logger.info(
+            String.format("Checking channel: %s with lower case in self declared", provider));
         provider = orgProviderMap.get(userDeclareEntity.getProvider().toLowerCase());
       }
       // Skip records which contains orgId which no longer exists in the system.


### PR DESCRIPTION
self declared  submitted to one state may be migrated to other state user.
In some cases the case of the channel is different when it is migrated to state.
 userid                               | idtype                     | provider | originalidtype             | originalprovider

 f138dcb7-609a-4ce1-aa1d-c6c2c79f8059 | declared-ext-id | mp |declared-ext-id |  MP
 f138dcb7-609a-4ce1-aa1d-c6c2c79f8059 |  declared-school-name | mp | declared-school-name | MP
 f138dcb7-609a-4ce1-aa1d-c6c2c79f8059 | declared-school-udise-code |       mp | declared-school-udise-code | MP
 f138dcb7-609a-4ce1-aa1d-c6c2c79f8059 | mp |mp | mp |mp

**FIX**: It will only look for selfdeclared records to update the channel info